### PR TITLE
feat : user model add

### DIFF
--- a/BE/prisma/migrations/20240527083627_add_user_model/migration.sql
+++ b/BE/prisma/migrations/20240527083627_add_user_model/migration.sql
@@ -1,0 +1,26 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `password` on the `Studies` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Studies" DROP COLUMN "password";
+
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "studiesId" TEXT NOT NULL,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_password_key" ON "User"("password");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_studiesId_key" ON "User"("studiesId");
+
+-- AddForeignKey
+ALTER TABLE "User" ADD CONSTRAINT "User_studiesId_fkey" FOREIGN KEY ("studiesId") REFERENCES "Studies"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/BE/prisma/schema.prisma
+++ b/BE/prisma/schema.prisma
@@ -13,10 +13,16 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+model User {
+  id        String  @id @default(uuid())
+  password  String  @unique
+  study     Studies @relation(fields: [studiesId], references: [id])
+  studiesId String  @unique
+}
+
 model Studies {
   id             String           @id @default(uuid())
   nickName       String           @unique
-  password       String
   name           String
   description    String
   points         Int              @default(0)
@@ -29,6 +35,7 @@ model Studies {
   Habit          Habit[]
   HabitTracker   HabitTracker[]
   CompletedHabit CompletedHabit[]
+  User User?
 }
 
 model Reaction {


### PR DESCRIPTION
## 구현사항
- [x] user model 추가함

## 사용방법
user api 추가할 예정임.
- study/studyId로 patch or delete하거나
  study/studyId/habit 집입, 수정, 삭제, 오늘의 집중에 진입 시 해당 스터디의 비밀번호 확인을 위해 추가하였고,
  사용은 비밀번호 입력후 버튼에 user/api로 전송하여 확인한다
